### PR TITLE
bug : 1:n 토큰 관리 오류 수정, 전체 토큰 삭제 기능 추가 (#36)

### DIFF
--- a/src/main/java/Mefo/server/global/firebase/controller/FirebaseController.java
+++ b/src/main/java/Mefo/server/global/firebase/controller/FirebaseController.java
@@ -36,10 +36,19 @@ public class FirebaseController {
 
     @Transactional
     @DeleteMapping("/delete")
-    @Operation(summary = "토큰 삭제 요청하기")
+    @Operation(summary = "특정 기기 토큰 삭제 요청하기")
     public ApiResponse<String> deleteToken(Authentication authentication, @RequestBody DeviceRequest deviceRequest){
         User user = userService.getLoginUser(authentication.getName());
         firebaseService.deleteToken(user, deviceRequest.getDevice());
+        return new ApiResponse<>(204, null);
+    }
+
+    @Transactional
+    @DeleteMapping("/deleteAll")
+    @Operation(summary = "모든 토큰 삭제 요청하기")
+    public ApiResponse<String> deleteAllToken(Authentication authentication){
+        User user = userService.getLoginUser(authentication.getName());
+        firebaseService.deleteAllToken(user);
         return new ApiResponse<>(204, null);
     }
 

--- a/src/main/java/Mefo/server/global/firebase/entity/FirebaseToken.java
+++ b/src/main/java/Mefo/server/global/firebase/entity/FirebaseToken.java
@@ -12,17 +12,24 @@ import lombok.NoArgsConstructor;
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "firebase_token",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "device"})
+        }
+)
 public class FirebaseToken extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")
     private User user;
 
     private String device;
 
+    @Column(name = "fcm_token", unique = true)
     private String fcmToken;
 
     public FirebaseToken(User user, String device, String fcmToken){

--- a/src/main/java/Mefo/server/global/firebase/service/FirebaseService.java
+++ b/src/main/java/Mefo/server/global/firebase/service/FirebaseService.java
@@ -58,13 +58,21 @@ public class FirebaseService {
 //        return token;
 //    }
 
+    //특정 기기 토큰 삭제하기
     @Transactional
     public void deleteToken(User user, String device){
-        Optional<FirebaseToken> fcmtoken = firebaseRepository.findByUserIdAndDevice(user.getId(), device);
+        Optional<FirebaseToken> fcmToken = firebaseRepository.findByUserIdAndDevice(user.getId(), device);
         FirebaseToken token;
-        if (fcmtoken.isPresent()){
-            token = fcmtoken.get();
+        if (fcmToken.isPresent()){
+            token = fcmToken.get();
             firebaseRepository.delete(token);
         }
+    }
+
+    //모든 토큰 삭제하기
+    @Transactional
+    public void deleteAllToken(User user){
+        List<FirebaseToken> fcmTokens = firebaseRepository.findAllByUserId(user.getId());
+        firebaseRepository.deleteAll(fcmTokens);
     }
 }


### PR DESCRIPTION
## PULL REQUEST

###  🧩 작업중인 브랜치

- #36 

### 💡 관련 이슈

- 관련 이슈를 입력해주세요.

### ⚡️ 작업 배경

- 유저가 여러 개의 토큰을 가질 수 없던 오류 수정

### 🔑 주요 변경사항

- 유저와 fcm 토큰 간 1:n 관계 가능하게 변경
- 같은 fcmtoken이 여러 번 사용될 수 없게 방지
- 유저가 같은 device에 대한 토큰을 여러 개 가질 수 없게 방지